### PR TITLE
Fixing bug in rcut and rcutmax values when considering Coulomb interactions 

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1296,17 +1296,19 @@ void write_pair_distribution_file()
         int col = g_config.atoms[i].neigh[j].col[0];
 
         if (col == k) {
-          pos = (int)(g_config.atoms[i].neigh[j].r / pair_dist[k]);
+          if (g_config.atoms[i].neigh[j].r < g_pot.calc_pot.end[k]) {
+            pos = (int)(g_config.atoms[i].neigh[j].r / pair_dist[k]);
 #if defined(DEBUG)
-          if (g_config.atoms[i].neigh[j].r <= 1) {
-            warning("Short distance (%f) found.\n",
-                    g_config.atoms[i].neigh[j].r);
-            warning("\tatom=%d neighbor=%d\n", i, j);
-          }
+            if (g_config.atoms[i].neigh[j].r <= 1) {
+              warning("Short distance (%f) found.\n",
+                      g_config.atoms[i].neigh[j].r);
+              warning("\tatom=%d neighbor=%d\n", i, j);
+            }
 #endif  // DEBUG
-          pair_table[k * pair_steps + pos]++;
-          if ((int)pair_table[k * pair_steps + pos] > max_count)
-            max_count = (int)pair_table[k * pair_steps + pos];
+            pair_table[k * pair_steps + pos]++;
+            if ((int)pair_table[k * pair_steps + pos] > max_count)
+              max_count = (int)pair_table[k * pair_steps + pos];
+          }
         }
       }
     }

--- a/src/potential_input.c
+++ b/src/potential_input.c
@@ -512,6 +512,15 @@ void calculate_cutoffs()
   }
 #endif  // EAM || ADP || MEAM
 
+#if defined(COULOMB)
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < n; j++) {
+      g_config.rcut[i * n + j] =
+          MAX(g_config.rcut[i * n + j], g_config.dp_cut);
+    }
+  }
+#endif  // COULOMB
+
   for (int i = 0; i < n; i++) {
     for (int j = 0; j < n; j++) {
       g_config.rcutmin = MIN(g_config.rcutmin, g_config.rcut[i + n * j]);


### PR DESCRIPTION
These changes fix a present bug in which, when considering Coulomb interactions, its cutoff (dp_cut) was not taken into account for building the Neighbours Table and when comparing Box Sizes with cutoffs.
