### PR TITLE
DSF sum for electrostatics

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -249,6 +249,9 @@ ifneq (,$(strip $(findstring coulomb,${MAKETARGET})))
   endif
   CFLAGS  += -DCOULOMB
   INTERACTION = 1
+  ifneq (,$(strip $(findstring dsf,${MAKETARGET})))
+    CFLAGS  += -DDSF
+  endif
 endif
 
 # DIPOLE
@@ -431,6 +434,8 @@ endif
 # How to link
 ${MAKETARGET}: ${OBJECTS}
 	@echo " [LD] $@"
+	@echo -e "\nCompiled with options"
+	@echo -e "CC=${CC} \nCFLAGS=${CFLAGS} \nLIBS=${LIBS}\n"
 ifeq (,${BIN_DIR})
 	@${CC} ${LFLAGS_${PARALLEL}} -o $@ ${OBJECTS} ${LIBS}
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -258,8 +258,11 @@ endif
 ifneq (,$(strip $(findstring dipole,${MAKETARGET})))
   ifeq (,$(strip $(findstring eam,${MAKETARGET})))
     ifneq (,$(findstring 1,${INTERACTION}))
-      ERROR += More than one potential model specified
+      ERROR += More than one potential model specified\n
     endif
+  endif
+  ifneq (,$(strip $(findstring dsf,${MAKETARGET})))
+      ERROR += DIPOLE and DSF are not currently compatible
   endif
   ifeq (,$(strip $(findstring apot,${MAKETARGET})))
     ERROR += DIPOLE does not support tabulated potentials

--- a/src/force_elstat.c
+++ b/src/force_elstat.c
@@ -317,9 +317,13 @@ double calc_forces(double* xi_opt, double* forces, int flag)
 
             /* updating tail-functions - only necessary with variing kappa */
             if (!apt->sw_kappa)
-              elstat_shift(neigh->r, dp_kappa, &neigh->fnval_el,
+#if defined(DSF)
+	    elstat_dsf(neigh->r, dp_kappa, &neigh->fnval_el,
                            &neigh->grad_el, &neigh->ggrad_el);
-
+#else
+	    elstat_shift(neigh->r, dp_kappa, &neigh->fnval_el,
+                           &neigh->grad_el, &neigh->ggrad_el);
+#endif
             /* In small cells, an atom might interact with itself */
             self = (neigh->nr == i + g_config.cnfstart[h]) ? 1 : 0;
 
@@ -792,6 +796,10 @@ double calc_forces(double* xi_opt, double* forces, int flag)
         /* F I F T H  loop: self energy contributions and sum-up force
          * contributions */
         double qq;
+#if defined(DSF)
+	double fnval_cut, gtail_cut, ggrad_cut;
+        elstat_value(g_config.dp_cut, dp_kappa, &fnval_cut, &gtail_cut, &ggrad_cut);
+#endif //DSF
 #if defined(DIPOLE)
         double pp;
 #endif                                             // DIPOLE
@@ -804,7 +812,12 @@ double calc_forces(double* xi_opt, double* forces, int flag)
           /* self energy contributions */
           if (charge[type1]) {
             qq = charge[type1] * charge[type1];
+#if defined(DSF)
+	    fnval = qq * ( DP_EPS * dp_kappa / sqrt(M_PI) +
+	       (fnval_cut - gtail_cut * g_config.dp_cut * g_config.dp_cut )*0.5 );
+#else
             fnval = DP_EPS * dp_kappa * qq / sqrt(M_PI);
+#endif //DSF
             forces[g_calc.energy_p + h] -= fnval;
           }
 #if defined(DIPOLE)

--- a/src/functions.h
+++ b/src/functions.h
@@ -64,7 +64,9 @@ void debug_apot();
 #if defined(COULOMB)
 void elstat_value(double, double, double*, double*, double*);
 void elstat_shift(double, double, double*, double*, double*);
+#if defined(DSF)
 void elstat_dsf(double, double, double*, double*, double*);
+#endif
 void init_tails(double);
 #endif  // COULOMB
 #if defined(DIPOLE)

--- a/src/functions.h
+++ b/src/functions.h
@@ -64,6 +64,7 @@ void debug_apot();
 #if defined(COULOMB)
 void elstat_value(double, double, double*, double*, double*);
 void elstat_shift(double, double, double*, double*, double*);
+void elstat_dsf(double, double, double*, double*, double*);
 void init_tails(double);
 #endif  // COULOMB
 #if defined(DIPOLE)


### PR DESCRIPTION

This is a pull request that deserve some discussion before merging, in case that happens.

I included the possibility to choose a different sum for electrostatics in potfit. Is the Damped Shifted Force as presented here http://dx.doi.org/10.1063/1.2206581 and included in LAMMPS in pair_styles with the coul/dsf  keyword. 

I checked already to reproduce properly total energies and atomic forces comparing against LAMMPS and everything looks good.

The idea as it is implemented now, is that the extra option **dsf** must be given at compile time in order to
get the potfit binary with DSF sum, i.e. 
`make potfit_apot_coulomb_dsf`  
If no **dsf** option is present, the compilation will keep using the current implementation.

What needs revision for sure is the DIPOLE option when using DSF.
I just kept that part in the elstat_dsf routine as it was in the previous case, since I couldn't understand in a first sight what should be precisely subtracted from fnval_tail and grad_tail in this new case.
   