### PR TITLE
re-add DSF option to Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -274,6 +274,9 @@ ifneq (,$(strip $(findstring coulomb,${MAKETARGET})))
     ERROR += "COULOMB does not support tabulated potentials!\\n"
   endif
   CFLAGS += -DCOULOMB
+  ifneq (,$(strip $(findstring dsf,${MAKETARGET})))
+    CFLAGS += -DDSF
+  endif
   INTERACTION = 1
 endif
 
@@ -283,6 +286,9 @@ ifneq (,$(strip $(findstring dipole,${MAKETARGET})))
     ifneq (,$(findstring 1,${INTERACTION}))
       ERROR += "More than one potential model specified!\\n"
     endif
+  endif
+  ifneq (,$(strip $(findstring dsf,${MAKETARGET})))
+      ERROR += "DIPOLE and DSF are not currently compatible!\\n"
   endif
   ifeq (,$(strip $(findstring apot,${MAKETARGET})))
     ERROR += "DIPOLE does not support tabulated potentials!\\n"


### PR DESCRIPTION
Hi @dschopf 
@arielzn alerted me to an irregularity in the commit https://github.com/potfit/potfit/commit/8815ef194b24882d2d5aa05b99b3bdb26797fbf9 which appears to remove the DSF option used to enforce a different way in cutting of long-range interaction. This appears to be my fault, as I somehow missed that change when I created the openkim branch, from where it propagated into trunk. 
This change should fix it again, as it undoes these changes.
Cheers,
Peter