### PR TITLE
global parameters always required in potential file

### DIFF
--- a/src/mpi_utils.c
+++ b/src/mpi_utils.c
@@ -554,6 +554,7 @@ int broadcast_calcpot_table()
 int broadcast_apot_table()
 {
 #if defined(APOT)
+  CHECK_RETURN(MPI_Bcast(&g_param.enable_glob, 1, MPI_INT, 0, MPI_COMM_WORLD));
   CHECK_RETURN(MPI_Bcast(&g_param.enable_cp, 1, MPI_INT, 0, MPI_COMM_WORLD));
   CHECK_RETURN(MPI_Bcast(&g_pot.opt_pot.len, 1, MPI_INT, 0, MPI_COMM_WORLD));
   CHECK_RETURN(

--- a/src/params.c
+++ b/src/params.c
@@ -200,6 +200,11 @@ void read_parameter_file(char const* param_file)
       get_param_double("plotmin", &g_param.plotmin, line, param_file, DBL_MIN,
                        DBL_MAX);
     }
+    // to enable the use of global parameters
+    else if (strcasecmp(token, "enable_glob") == 0) {
+      get_param_int("enable_glob", &g_param.enable_glob, line, param_file, INT_MIN,
+                    INT_MAX);
+    }
 #if defined(PAIR)
     // exclude chemical potential from energy calculations
     else if (strcasecmp(token, "enable_cp") == 0) {
@@ -390,6 +395,9 @@ void check_parameters_complete(char const* paramfile)
   if (g_param.plotmin < 0)
     error(1, "Missing parameter or invalid value in %s : plotmin is \"%f\"\n",
           paramfile, g_param.plotmin);
+  if (g_param.enable_glob != 0 && g_param.enable_glob != 1)
+    error(1, "Missing parameter or invalid value in %s : enable_glob is \"%d\"\n",
+          paramfile, g_param.enable_glob);
 #if defined(PAIR)
   if (g_param.enable_cp != 0 && g_param.enable_cp != 1)
     error(1, "Missing parameter or invalid value in %s : enable_cp is \"%d\"\n",

--- a/src/potential_input_f0.c
+++ b/src/potential_input_f0.c
@@ -340,7 +340,7 @@ void read_chemical_potentials(apot_state* pstate)
     /* shortcut for apt->number */
     int i = apt->number;
 
-    /* allocate memory for global parameters */
+    /* allocate memory for chemical potentials parameters */
     apt->names = (char**)Realloc(apt->names, (i + 1) * sizeof(char*));
     apt->names[i] = (char*)Malloc(20 * sizeof(char));
     strcpy(apt->names[i], "chemical potentials");
@@ -598,115 +598,117 @@ void read_global_parameters(apot_state* pstate)
 
   pot_table_t* pt = &g_pot.opt_pot;
 
-  /* skip to global section */
-  fsetpos(pstate->pfile, &pstate->startpos);
-  do {
-    fgetpos(pstate->pfile, &filepos);
-    if (1 != fscanf(pstate->pfile, "%s", buffer))
-      error(1, "Error while searching for global parameters\n");
-  } while (strcmp(buffer, "global") != 0 && !feof(pstate->pfile));
-  fsetpos(pstate->pfile, &filepos);
+  if (g_param.enable_glob) {
+    /* skip to global section */
+    fsetpos(pstate->pfile, &pstate->startpos);
+    do {
+      fgetpos(pstate->pfile, &filepos);
+      if (1 != fscanf(pstate->pfile, "%s", buffer))
+        error(1, "Error while searching for global parameters\n");
+    } while (strcmp(buffer, "global") != 0 && !feof(pstate->pfile));
+    fsetpos(pstate->pfile, &filepos);
 
-  /* check for global keyword */
-  if (strcmp(buffer, "global") == 0) {
-    if (2 > fscanf(pstate->pfile, "%s %d", buffer, &apt->globals))
-      error(1, "Premature end of potential file %s\n", pstate->filename);
-    g_pot.have_globals = 1;
-    apt->total_par += apt->globals;
+    /* check for global keyword */
+    if (strcmp(buffer, "global") == 0) {
+      if (2 > fscanf(pstate->pfile, "%s %d", buffer, &apt->globals))
+        error(1, "Premature end of potential file %s\n", pstate->filename);
+      g_pot.have_globals = 1;
+      apt->total_par += apt->globals;
 
-    int i = apt->number + g_param.enable_cp;
-    int j = apt->globals;
-    g_pot.global_pot = i;
+      int i = apt->number + g_param.enable_cp;
+      int j = apt->globals;
+      g_pot.global_pot = i;
 
-    /* allocate memory for global parameters */
-    apt->names =
-        (char**)Realloc(apt->names, (g_pot.global_pot + 1) * sizeof(char*));
-    apt->names[g_pot.global_pot] = (char*)Malloc(20 * sizeof(char));
-    strcpy(apt->names[g_pot.global_pot], "global parameters");
+      /* allocate memory for global parameters */
+      apt->names =
+          (char**)Realloc(apt->names, (g_pot.global_pot + 1) * sizeof(char*));
+      apt->names[g_pot.global_pot] = (char*)Malloc(20 * sizeof(char));
+      strcpy(apt->names[g_pot.global_pot], "global parameters");
 
-    apt->n_glob = (int*)Malloc(apt->globals * sizeof(int));
+      apt->n_glob = (int*)Malloc(apt->globals * sizeof(int));
 
-    apt->global_idx = (int***)Malloc(apt->globals * sizeof(int**));
+      apt->global_idx = (int***)Malloc(apt->globals * sizeof(int**));
 
-    apt->values = (double**)Realloc(apt->values,
-                                    (g_pot.global_pot + 1) * sizeof(double*));
-    apt->values[g_pot.global_pot] = (double*)Malloc(j * sizeof(double));
+      apt->values = (double**)Realloc(apt->values,
+                                      (g_pot.global_pot + 1) * sizeof(double*));
+      apt->values[g_pot.global_pot] = (double*)Malloc(j * sizeof(double));
 
-    apt->invar_par =
-        (int**)Realloc(apt->invar_par, (g_pot.global_pot + 1) * sizeof(int*));
-    apt->invar_par[g_pot.global_pot] = (int*)Malloc((j + 1) * sizeof(int));
+      apt->invar_par =
+          (int**)Realloc(apt->invar_par, (g_pot.global_pot + 1) * sizeof(int*));
+      apt->invar_par[g_pot.global_pot] = (int*)Malloc((j + 1) * sizeof(int));
 
-    apt->pmin =
-        (double**)Realloc(apt->pmin, (g_pot.global_pot + 1) * sizeof(double*));
-    apt->pmin[g_pot.global_pot] = (double*)Malloc(j * sizeof(double));
+      apt->pmin =
+          (double**)Realloc(apt->pmin, (g_pot.global_pot + 1) * sizeof(double*));
+      apt->pmin[g_pot.global_pot] = (double*)Malloc(j * sizeof(double));
 
-    apt->pmax =
-        (double**)Realloc(apt->pmax, (g_pot.global_pot + 1) * sizeof(double*));
-    apt->pmax[g_pot.global_pot] = (double*)Malloc(j * sizeof(double));
+      apt->pmax =
+          (double**)Realloc(apt->pmax, (g_pot.global_pot + 1) * sizeof(double*));
+      apt->pmax[g_pot.global_pot] = (double*)Malloc(j * sizeof(double));
 
-    apt->param_name = (char***)Realloc(apt->param_name,
-                                       (g_pot.global_pot + 1) * sizeof(char**));
-    apt->param_name[g_pot.global_pot] = (char**)Malloc(j * sizeof(char*));
+      apt->param_name = (char***)Realloc(apt->param_name,
+                                         (g_pot.global_pot + 1) * sizeof(char**));
+      apt->param_name[g_pot.global_pot] = (char**)Malloc(j * sizeof(char*));
 
-    pt->first = (int*)Realloc(pt->first, (g_pot.global_pot + 1) * sizeof(int));
+      pt->first = (int*)Realloc(pt->first, (g_pot.global_pot + 1) * sizeof(int));
 
-    /* read the global parameters */
-    for (j = 0; j < apt->globals; j++) {
-      apt->param_name[g_pot.global_pot][j] = (char*)Malloc(30 * sizeof(char));
+      /* read the global parameters */
+      for (j = 0; j < apt->globals; j++) {
+        apt->param_name[g_pot.global_pot][j] = (char*)Malloc(30 * sizeof(char));
 
-      strcpy(apt->param_name[g_pot.global_pot][j], "\0");
-      int ret_val = fscanf(
-          pstate->pfile, "%s %lf %lf %lf", apt->param_name[g_pot.global_pot][j],
-          &apt->values[g_pot.global_pot][j], &apt->pmin[g_pot.global_pot][j],
-          &apt->pmax[g_pot.global_pot][j]);
-      if (4 > ret_val)
-        if (strcmp(apt->param_name[g_pot.global_pot][j], "type") == 0) {
-          error(0, "Not enough global parameters!\n");
-          error(1, "You specified %d parameter(s), but needed are %d.\n", j, apt->globals);
+        strcpy(apt->param_name[g_pot.global_pot][j], "\0");
+        int ret_val = fscanf(
+            pstate->pfile, "%s %lf %lf %lf", apt->param_name[g_pot.global_pot][j],
+            &apt->values[g_pot.global_pot][j], &apt->pmin[g_pot.global_pot][j],
+            &apt->pmax[g_pot.global_pot][j]);
+        if (4 > ret_val)
+          if (strcmp(apt->param_name[g_pot.global_pot][j], "type") == 0) {
+            error(0, "Not enough global parameters!\n");
+            error(1, "You specified %d parameter(s), but needed are %d.\n", j, apt->globals);
+          }
+
+        /* check for duplicate names */
+        for (int k = j - 1; k >= 0; k--) {
+          if (strcmp(apt->param_name[g_pot.global_pot][j],
+                     apt->param_name[g_pot.global_pot][k]) == 0) {
+            error(0, "\nFound duplicate global parameter name!\n");
+            error(1, "Parameter #%d (%s) is the same as #%d (%s)\n", j + 1,
+                  apt->param_name[g_pot.global_pot][j], k + 1,
+                  apt->param_name[g_pot.global_pot][k]);
+          }
         }
 
-      /* check for duplicate names */
-      for (int k = j - 1; k >= 0; k--) {
-        if (strcmp(apt->param_name[g_pot.global_pot][j],
-                   apt->param_name[g_pot.global_pot][k]) == 0) {
-          error(0, "\nFound duplicate global parameter name!\n");
-          error(1, "Parameter #%d (%s) is the same as #%d (%s)\n", j + 1,
-                apt->param_name[g_pot.global_pot][j], k + 1,
-                apt->param_name[g_pot.global_pot][k]);
+        apt->n_glob[j] = 0;
+
+        /* check for invariance and proper value (respect boundaries) */
+        /* parameter will not be optimized if min==max */
+        apt->invar_par[i][j] = 0;
+
+        if (apt->pmin[i][j] == apt->pmax[i][j]) {
+          apt->invar_par[i][j] = 1;
+          apt->invar_par[i][apt->globals]++;
+        } else if (apt->pmin[i][j] > apt->pmax[i][j]) {
+          double temp = apt->pmin[i][j];
+          apt->pmin[i][j] = apt->pmax[i][j];
+          apt->pmax[i][j] = temp;
+        } else if ((apt->values[i][j] < apt->pmin[i][j]) ||
+                   (apt->values[i][j] > apt->pmax[i][j])) {
+          /* Only print warning if we are optimizing */
+          if (g_param.opt) {
+            if (apt->values[i][j] < apt->pmin[i][j])
+              apt->values[i][j] = apt->pmin[i][j];
+            if (apt->values[i][j] > apt->pmax[i][j])
+              apt->values[i][j] = apt->pmax[i][j];
+            warning("Starting value for global parameter #%d is ", j + 1);
+            warning("outside of specified adjustment range.\n");
+            warning("Resetting it to %f.\n", j + 1, apt->values[i][j]);
+            if (apt->values[i][j] == 0)
+              warning("New value is 0 ! Please be careful about this.\n");
+          }
         }
       }
 
-      apt->n_glob[j] = 0;
-
-      /* check for invariance and proper value (respect boundaries) */
-      /* parameter will not be optimized if min==max */
-      apt->invar_par[i][j] = 0;
-
-      if (apt->pmin[i][j] == apt->pmax[i][j]) {
-        apt->invar_par[i][j] = 1;
-        apt->invar_par[i][apt->globals]++;
-      } else if (apt->pmin[i][j] > apt->pmax[i][j]) {
-        double temp = apt->pmin[i][j];
-        apt->pmin[i][j] = apt->pmax[i][j];
-        apt->pmax[i][j] = temp;
-      } else if ((apt->values[i][j] < apt->pmin[i][j]) ||
-                 (apt->values[i][j] > apt->pmax[i][j])) {
-        /* Only print warning if we are optimizing */
-        if (g_param.opt) {
-          if (apt->values[i][j] < apt->pmin[i][j])
-            apt->values[i][j] = apt->pmin[i][j];
-          if (apt->values[i][j] > apt->pmax[i][j])
-            apt->values[i][j] = apt->pmax[i][j];
-          warning("Starting value for global parameter #%d is ", j + 1);
-          warning("outside of specified adjustment range.\n");
-          warning("Resetting it to %f.\n", j + 1, apt->values[i][j]);
-          if (apt->values[i][j] == 0)
-            warning("New value is 0 ! Please be careful about this.\n");
-        }
-      }
+      printf(" - Read %d global parameter(s)\n", apt->globals);
     }
-
-    printf(" - Read %d global parameter(s)\n", apt->globals);
   }
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -471,7 +471,7 @@ typedef struct {
 #if defined(APOT)
   int compnodes; /* how many additional composition nodes */
   int enable_cp; /* switch chemical potential on/off */
-  int enable_glob; /* switch chemical potential on/off */
+  int enable_glob; /* switch global parameters on/off */
   double apot_punish_value;
   double plotmin;           /* minimum for plotfile */
 #endif                      // APOT

--- a/src/types.h
+++ b/src/types.h
@@ -471,6 +471,7 @@ typedef struct {
 #if defined(APOT)
   int compnodes; /* how many additional composition nodes */
   int enable_cp; /* switch chemical potential on/off */
+  int enable_glob; /* switch chemical potential on/off */
   double apot_punish_value;
   double plotmin;           /* minimum for plotfile */
 #endif                      // APOT


### PR DESCRIPTION
Hi,

I realized that in the current version global parameters are always required to be defined in the potential file, even if they are not used. 

That issue was inserted in src/potential_input_f0.c when implementing the error check in this commit
https://github.com/potfit/potfit/commit/8aeb2079aff8fabe593f0e4a4af835a6f9c30345#diff-27593524623bc107fe43c792f5fa3d28
If no global keyword is found in the potential file, the error
       error(1, "Error while searching for global parameters\n"); 
is always triggered, no matter if no global are used at all.

I provide a patch that solves this issue, by cloning the idea of the enable_cp parameter in the parameters file, defining a new enable_glob one.

