### PR TITLE
Remove support for outdated ACML. 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+20180909
+- Remove support for ACML. For details see https://github.com/potfit/potfit/issues/43
+
 20180709:
 - Fix stiweb and tersoff potentials when used together with global parameters
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -112,12 +112,9 @@ SHELL = /bin/bash
 
 SYSTEM = x86_64-gcc
 
-# Base directory of your installation of the MKL or ACML
+# Base directory of your installation of the MKL
 
 MKLDIR      = /opt/intel/composer_xe_2015.1.133/mkl
-ACML4DIR    = /opt/acml4.4.0/gfortran64
-ACML5DIR    = /opt/acml/gfortran64
-LIBMDIR     = /opt/acml/libm
 
 ###########################################################################
 #
@@ -138,11 +135,7 @@ else
   TARGET = LINUX
 endif
 
-ifneq (,$(strip $(findstring acml4,${MAKETARGET})))
-  MATH_LIB = ACML4
-else ifneq (,$(strip $(findstring acml5,${MAKETARGET})))
-  MATH_LIB = ACML5
-else ifneq (,$(strip $(findstring mkl,${MAKETARGET})))
+ifneq (,$(strip $(findstring mkl,${MAKETARGET})))
   MATH_LIB = MKL
 else
   ifeq (${TARGET},MACOS)
@@ -180,13 +173,6 @@ else ifeq (${MATH_LIB},MKL)
   CINCLUDE      += -I${MKLDIR}/include
   LIBS          += -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential \
                    -lmkl_core -Wl,--end-group -lpthread
-else ifeq (${MATH_LIB},ACML4)
-  CINCLUDE      += -I${ACML4DIR}/include
-  LIBS          = -L${ACML4PATH} -lpthread -lacml -lacml_mv
-else ifeq (${MATH_LIB},ACML5)
-  LIBMPATH      = ${LIBMDIR}/lib/dynamic
-  CINCLUDE      += -I${ACML5DIR}/include -I${LIBMDIR}/include
-  LIBS          += -L${ACML5PATH} -L${LIBMPATH} -lpthread -lacml -lamdlibm
 endif
 
 endif # x86_64-icc
@@ -215,13 +201,6 @@ else ifeq (${MATH_LIB},MKL)
   CINCLUDE      += -I${MKLDIR}/include
   LIBS          += -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core \
                    -Wl,--end-group -lpthread -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML4)
-  CINCLUDE      += -I${ACML4DIR}/include
-  LIBS          += -L${ACML4PATH} -lpthread -lacml -lacml_mv -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML5)
-  LIBMPATH      = ${LIBMDIR}/lib/dynamic
-  CINCLUDE      += -I${ACML5DIR}/include -I${LIBMDIR}/include
-  LIBS          += -L${ACML5PATH} -L${LIBMPATH} -lpthread -lacml -lamdlibm -Wl,--as-needed
 endif
 
 endif # x86_64-gcc
@@ -249,13 +228,6 @@ else ifeq (${MATH_LIB},MKL)
   CINCLUDE      += -I${MKLDIR}/include
   LIBS          += -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core \
                    -Wl,--end-group -lpthread -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML4)
-  CINCLUDE      += -I${ACML4DIR}/include
-  LIBS          += -L${ACML4PATH} -lpthread -lacml -lacml_mv -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML5)
-  LIBMPATH      = ${LIBMDIR}/lib/dynamic
-  CINCLUDE      += -I${ACML5DIR}/include -I${LIBMDIR}/include
-  LIBS          += -L${ACML5PATH} -L${LIBMPATH} -lpthread -lacml -lamdlibm -Wl,--as-needed
 endif
 
 endif # x86_64-clang
@@ -287,13 +259,6 @@ else ifeq (${MATH_LIB},MKL)
   CINCLUDE      += -I${MKLDIR}/include
   LIBS          += -Wl,--start-group -lmkl_intel -lmkl_sequential -lmkl_core \
                    -Wl,--end-group -lpthread
-else ifeq (${MATH_LIB},ACML4)
-  CINCLUDE      += -I$(ACML4DIR)/include
-  LIBS          += -L${ACML4PATH} -lpthread -lacml
-else ifeq (${MATH_LIB},ACML5)
-  LIBMPATH      = ${LIBMDIR}/lib/dynamic
-  CINCLUDE      += -I$(ACML5DIR)/include -I${LIBMDIR}/include
-  LIBS          += -L${ACML5PATH} -L${LIBMPATH} -lpthread -lacml
 endif
 
 endif # i686-icc
@@ -320,13 +285,6 @@ else ifeq (${MATH_LIB},MKL)
   CINCLUDE      += -I${MKLDIR}/include
   LIBS          += -Wl,--start-group -lmkl_intel -lmkl_sequential -lmkl_core \
                    -Wl,--end-group -lpthread -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML4)
-  CINCLUDE      += -I$(ACML4DIR)/include
-  LIBS          += -L${ACML4PATH} -lpthread -lacml -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML5)
-  LIBMPATH      = ${LIBMDIR}/lib/dynamic
-  CINCLUDE      += -I$(ACML5DIR)/include -I${LIBMDIR}/include
-  LIBS          += -L${ACML5PATH} -L${LIBMPATH} -lpthread -lacml -Wl,--as-needed
 endif
 
 endif # i686-gcc
@@ -351,13 +309,6 @@ else ifeq (${MATH_LIB},MKL)
   LIBS          += -L${MKLDIR}/lib/intel64
   LIBS          += -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core \
                    -Wl,--end-group -lpthread -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML4)
-  CINCLUDE      += -I$(ACML4DIR)/include
-  LIBS          += -L${ACML4PATH} -lpthread -lacml -Wl,--as-needed
-else ifeq (${MATH_LIB},ACML5)
-  LIBMPATH      = ${LIBMDIR}/lib/dynamic
-  CINCLUDE      += -I$(ACML5DIR)/include -I${LIBMDIR}/include
-  LIBS          += -L${ACML5PATH} -L${LIBMPATH} -lpthread -lacml -Wl,--as-needed
 endif
 
 endif # kim-toolchain

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,8 +37,6 @@ STRIP 		= $(shell which strip 2> /dev/null)
 LIBS		+= -lm
 MPI_FLAGS	+= -DMPI
 DEBUG_FLAGS	+= -DDEBUG
-ACML4PATH 	= ${ACML4DIR}/lib
-ACML5PATH 	= ${ACML5DIR}/lib
 BIN_DIR 	= bin/
 
 ###########################################################################
@@ -413,25 +411,6 @@ endif
 
 ifneq (,$(findstring contrib,${MAKETARGET}))
   CFLAGS += -DCONTRIB
-endif
-
-ifneq (,$(findstring mkl,${MAKETARGET}))
-  ifneq (,$(findstring acml,${MAKETARGET}))
-    ERROR += "ACML cannot be used together with MKL.\n"
-  endif
-endif
-
-# force acml4 or acml5 over acml
-ifneq (,$(findstring acml,${MAKETARGET}))
-  ifneq (,$(findstring mkl,${MAKETARGET}))
-    ERROR += "ACML cannot be used together with MKL.\n"
-  endif
-  ifeq (,$(findstring acml4,${MAKETARGET}))
-    ifeq (,$(findstring acml5,${MAKETARGET}))
-      ERROR += "The acml target is obsolete. Please use acml4 or acml5.\n"
-    endif
-  endif
-  CFLAGS += -DACML
 endif
 
 ifneq (,$(findstring resc,${MAKETARGET}))

--- a/src/powell_lsq.c
+++ b/src/powell_lsq.c
@@ -137,6 +137,11 @@ void run_powell_lsq(double* xi)
   /* Vector pointing into correct dir'n */
   double* delta = (double*)Malloc(g_calc.ndimtot * sizeof(double)); /* ==0 */
 
+  int worksize = 64 * g_calc.ndim;
+  // work array to be used by dsysvx
+  double* work = (double*)Malloc(worksize * sizeof(double));
+  int* iwork = (int*)Malloc(g_calc.ndim * sizeof(int));
+
   /* calculate the first force */
   F1 = calc_forces(xi, forces_1, 0);
 

--- a/src/powell_lsq.c
+++ b/src/powell_lsq.c
@@ -41,13 +41,11 @@
 
 #if defined(MKL)
 #include <mkl_lapack.h>
-#elif defined(ACML)
-#include <acml.h>
 #elif defined(__ACCELERATE__)
 #include <Accelerate/Accelerate.h>
 #else
 #error No math library defined!
-#endif  // ACML
+#endif  // MKL
 
 #include "bracket.h"
 #include "force.h"
@@ -139,13 +137,6 @@ void run_powell_lsq(double* xi)
   /* Vector pointing into correct dir'n */
   double* delta = (double*)Malloc(g_calc.ndimtot * sizeof(double)); /* ==0 */
 
-#if !defined(ACML) // work arrays not needed for ACML
-  int worksize = 64 * g_calc.ndim;
-  // work array to be used by dsysvx
-  double* work = (double*)Malloc(worksize * sizeof(double));
-  int* iwork = (int*)Malloc(g_calc.ndim * sizeof(int));
-#endif  // ACML
-
   /* calculate the first force */
   F1 = calc_forces(xi, forces_1, 0);
 
@@ -228,10 +219,6 @@ void run_powell_lsq(double* xi)
       dsysvx(fact, uplo, &g_calc.ndim, &j, &lineqsys[0][0], &g_calc.ndim,
              &les_inverse[0][0], &g_calc.ndim, perm_indx, p, &g_calc.ndim, q,
              &g_calc.ndim, &cond, &ferror, &berror, work, &worksize, iwork, &i);
-#elif defined(ACML)
-      dsysvx(fact[0], uplo[0], g_calc.ndim, j, &lineqsys[0][0], g_calc.ndim,
-             &les_inverse[0][0], g_calc.ndim, perm_indx, p, g_calc.ndim, q,
-             g_calc.ndim, &cond, &ferror, &berror, &i);
 #elif defined(__ACCELERATE__)
       dsysvx_(fact, uplo, &g_calc.ndim, &j, &lineqsys[0][0], &g_calc.ndim,
              &les_inverse[0][0], &g_calc.ndim, perm_indx, p, &g_calc.ndim, q,

--- a/src/utils.c
+++ b/src/utils.c
@@ -46,8 +46,6 @@
 // 64-bit
 #if defined(MKL)
 #include <mkl_vml.h>
-#elif defined(ACML)
-#include <amdlibm.h>
 #elif defined(__ACCELERATE__)
 #include <Accelerate/Accelerate.h>
 #else
@@ -90,8 +88,6 @@ void power_1(double* result, const double* x, const double* y)
 #else
 #if defined(MKL)
   vdPow(1, x, y, result);
-#elif defined(ACML)
-  *result = pow(*x, *y);
 #elif defined(__ACCELERATE__)
   vvpow(result, y, x, &g_dim);
 #endif
@@ -107,10 +103,6 @@ void power_m(int dim, double* result, const double* x, const double* y)
 #else
 #if defined(MKL)
   vdPow(dim, x, y, result);
-#elif defined(ACML)
-  int i;
-  for (i = 0; i < dim; i++)
-    *(result + i) = pow(*(x + i), *(y + i));
 #elif defined(__ACCELERATE__)
   vvpow(result, y, x, &dim);
 #endif

--- a/util/devel/check_potfit.py
+++ b/util/devel/check_potfit.py
@@ -61,7 +61,6 @@ def parse_arguments():
                         type=int, required=False, help='start at combination N')
     parser.add_argument('--count', metavar='N', default=-1,
                         type=int, required=False, help='only compile N versions')
-    parser.add_argument('--acml', action='store_true')
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--nproc', default=1, type=int, required=False,
                         help='number of processer cores for parallel compilation')
@@ -95,9 +94,6 @@ def get_working_arrays(args):
         special_options = special_kim_options
     else:
         raise RuntimeWarning('No interaction type defined!')
-
-    if args.acml:
-        string += '_acml5'
 
     if args.debug:
         string += '_debug'

--- a/util/devel/check_potfit_waf.py
+++ b/util/devel/check_potfit_waf.py
@@ -61,7 +61,6 @@ def parse_arguments():
                         type=int, required=False, help='start at combination N')
     parser.add_argument('--count', metavar='N', default=-1,
                         type=int, required=False, help='only compile N versions')
-    parser.add_argument('--acml', action='store_true')
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--compiler', choices=['clang', 'gcc', 'icc'], default='clang')
     return parser.parse_args()
@@ -97,10 +96,6 @@ def get_working_arrays(args):
         special_options = special_kim_options
     else:
         raise RuntimeWarning('No interaction type defined!')
-
-    if args.acml:
-        cmd.extend(['-l', 'acml'])
-        target_name += '_acml'
 
     if args.debug:
         cmd.append('--debug')

--- a/wscript
+++ b/wscript
@@ -57,11 +57,8 @@ POTENTIALS = [
 # Math libray settings
 
 MKLDIR = '/opt/intel/mkl'
-ACMLDIR = '/opt/acml/gfortran64'
-LIBMDIR = '/opt/acml/libm'
 
 supported_math_libs = [
-    ['acml', 'AMD Core Math Library V5.X (also requires amdlibm)'],
     ['mkl', 'Intel Math Kernel Library'],
 ]
 
@@ -97,8 +94,6 @@ def options(opt):
                       help='Select math library to use (default: %(default)s)', metavar='MATHLIB')
     libs.add_argument('--math-lib-base-dir', action='store', type=str,
                       help='Base directory of selected math library')
-    libs.add_argument('--math-lib-amdlibm-dir', action='store', type=str,
-                      help='R|Base directory for AMD libm replacement \n(only required for acml)')
     # debug options
     debug = opt.add_argument_group('potfit debugging options')
     debug.add_argument('--debug', action='store_true',
@@ -263,8 +258,6 @@ def _check_math_lib_options(cnf):
 
     The math library is checked by compiling some small code snippets
     """
-    global ACMLDIR
-    global LIBMDIR
     global MKLDIR
 
     if cnf.options.math_lib is None:
@@ -298,27 +291,10 @@ def _check_math_lib_options(cnf):
           }\n''', execute=True, msg='Compiling test MKL binary', okmsg='OK', errmsg='Failed', use=['POTFIT'])
         cnf.env.append_value('DEFINES_POTFIT', ['MKL'])
 
-    # ACML
-    if cnf.options.math_lib == 'acml':
-        if cnf.options.math_lib_base_dir:
-            ACMLDIR = cnf.options.math_lib_base_dir
-        if cnf.options.math_lib_amdlibm_dir:
-            LIBMDIR = cnf.options.math_lib_amdlibm_dir
-        cnf.env.append_value('INCLUDES_POTFIT', [ACMLDIR + '/include'])
-        cnf.env.append_value('LIBPATH_POTFIT', [ACMLDIR + '/lib'])
-        cnf.env.append_value('LIB_POTFIT', ['acml'])
-        cnf.env.append_value('INCLUDES_POTFIT', [LIBMDIR + '/include'])
-        cnf.env.append_value('LIBPATH_POTFIT', [LIBMDIR + '/lib/dynamic'])
-        cnf.env.append_value('LIB_POTFIT', ['amdlibm'])
-        cnf.check(header_name='acml.h', features='c cprogram', use=['POTFIT'])
-        cnf.check(header_name='amdlibm.h',
-                  features='c cprogram', use=['POTFIT'])
-        cnf.env.append_value('DEFINES_POTFIT', ['ACML'])
-
 
 def _generate_target_name(cnf):
     """
-    Function for generating the target name, e.g. potfit_apot_pair_acml
+    Function for generating the target name, e.g. potfit_apot_pair_mkl
     """
     name = 'potfit'
     if cnf.options.model and cnf.options.model != cnf.options.interaction:


### PR DESCRIPTION
Currently only MKL and Accelerate remain as supported math library.

Relates to #43 