### PR TITLE
Support other MPI implementations apart from OpenMPI

### DIFF
--- a/util/devel/check_potfit_waf.py
+++ b/util/devel/check_potfit_waf.py
@@ -2,10 +2,11 @@
 
 import argparse
 import copy
+import os
 import sys
 
 from itertools import chain, combinations
-from subprocess import call
+from subprocess import run
 
 # arrays for supported interactions
 
@@ -172,13 +173,19 @@ class check_potfit:
 
                 print('\nBuilding target {} ({}/{})'.format(target_str, count, num_targets))
 
-                call(['./waf', 'clean'])
-                retcode = call(['./waf', 'configure', *cmds, '--check-c-compiler={}'.format(self.compiler)])
-                if retcode:
+                run(['./waf', 'clean'])
+                my_env = os.environ.copy()
+                run_cmd = ['./waf', 'configure', *cmds]
+                if 'mpi' in build_string:
+                    my_env['OMPI_CC'] = self.compiler
+                else:
+                    run_cmd.append('--check-c-compiler={}'.format(self.compiler))
+                res = run(run_cmd, env=my_env)
+                if res.returncode:
                     print('Error when calling ./waf configure ({})'.format(retcode))
                     sys.exit(1)
-                retcode = call(['./waf'])
-                if retcode:
+                res = run(['./waf'])
+                if res.returncode:
                     sys.exit(1)
 
     def _prepare_arrays(self):
@@ -237,13 +244,19 @@ class check_potfit:
 
             print('Building target {} ({}/{})\n'.format(target_str, count, num_targets))
 
-            call(['./waf', 'clean'])
-            retcode = call(['./waf', 'configure', *cmds, '--check-c-compiler={}'.format(self.compiler)])
-            if retcode:
+            run(['./waf', 'clean'])
+            my_env = os.environ.copy()
+            run_cmd = ['./waf', 'configure', *cmds]
+            if 'mpi' in build_string:
+                my_env['OMPI_CC'] = self.compiler
+            else:
+                run_cmd.append('--check-c-compiler={}'.format(self.compiler))
+            res = run(run_cmd, env=my_env)
+            if res.returncode:
                 print('Error when calling ./waf configure ({})'.format(retcode))
                 sys.exit(1)
-            retcode = call(['./waf'])
-            if retcode:
+            res = run(['./waf'])
+            if res.returncode:
                 sys.exit(1)
 
 

--- a/util/devel/check_potfit_waf.py
+++ b/util/devel/check_potfit_waf.py
@@ -221,12 +221,12 @@ class check_potfit:
 
         count = 0
         option_list = list(KIM_OPTIONS)
-        target_str = 'potfit_' + self.model
         for s in SPECIAL_KIM_OPTIONS:
             if s[0] == i:
                 option_list.extend(s[1])
                 break
         for build_string in all_subsets(option_list):
+            target_str = 'potfit_' + self.model
             count += 1
             if count < self.startpos:
                 continue

--- a/wscript
+++ b/wscript
@@ -226,6 +226,16 @@ def _check_compiler_options(cnf):
         cnf.check_cfg(package='libkim-api', args=['libkim-api >= 2.0.2', '--cflags', '--libs'], uselib_store='KIM')
     else:
         c_compiler[_platform] = ['icc', 'clang', 'gcc']
+
+    if cnf.options.enable_mpi:
+        if cnf.options.check_c_compiler:
+            cnf.fatal('--check-c-compiler cannot be used with MPI! Please use the MPI environment variable to set the compiler.')
+        cnf.add_os_flags('CC')
+        if cnf.env.CC:
+            cnf.fatal('Overriding the compiler with CC is not supported when MPI is enabled!')
+        else:
+            cnf.env.CC = 'mpicc'
+
     cnf.load('compiler_c')
 
     if cnf.options.asan:
@@ -262,16 +272,13 @@ def _check_compiler_options(cnf):
     else:
         cnf.env.append_value('LINKFLAGS_POTFIT', ['-Wl,--no-undefined,--as-needed,-z,relro,-z,now'])
 
+
 @conf
 def _check_mpi_compiler(cnf):
-    cnf.check_cfg(path='mpicc', args='--showme:compile', package='',
-                  uselib_store='POTFIT', msg='Checking MPI compiler command')
-    cnf.check_cfg(path='mpicc', args='--showme:link', package='',
-                  uselib_store='POTFIT', msg='Checking MPI linker flags')
     cnf.check(header_name='mpi.h', features='c cprogram', use=['POTFIT'])
     cnf.check_cc(
         fragment='#include <mpi.h>\nint main() { MPI_Init(NULL, NULL); MPI_Finalize(); }',
-        execute=True, msg='Compiling test MPI binary', okmsg='OK', errmsg='Failed', use=['POTFIT'])
+        execute=True, msg='Compiling MPI test binary', okmsg='OK', errmsg='Failed', use=['POTFIT'])
 
 
 @conf

--- a/wscript
+++ b/wscript
@@ -277,7 +277,7 @@ def _check_compiler_options(cnf):
 def _check_mpi_compiler(cnf):
     cnf.check(header_name='mpi.h', features='c cprogram', use=['POTFIT'])
     cnf.check_cc(
-        fragment='#include <mpi.h>\nint main() { MPI_Init(NULL, NULL); MPI_Finalize(); }',
+        fragment='#include <mpi.h>\n#include <stddef.h>\nint main() { MPI_Init(NULL, NULL); MPI_Finalize(); }',
         execute=True, msg='Compiling MPI test binary', okmsg='OK', errmsg='Failed', use=['POTFIT'])
 
 


### PR DESCRIPTION
These commits make waf actually use the mpicc command instead of trying to extract the compiler and linker flags and adding them to the acutal compiler.