### PR TITLE
Python3 support for plotapot

### DIFF
--- a/util/plotapot
+++ b/util/plotapot
@@ -65,7 +65,7 @@ def make_partition(interaction, n):
         pair.append(n%3)
 
     # eam distribution
-    for i in range(n/3):
+    for i in range(int(n/3)):
         transfer.append(3)
     if n % 3 != 0:
         transfer.append(n%3)


### PR DESCRIPTION
The utility plotapot doesn't always work with python3 due to integer division resulting in floating point numbers. This explicitly casts to integer in a call to range so that it works with both python2 and python3.