### PR TITLE
[castep2force] fix documentation of chemical potential flag to state the unit correctly

### DIFF
--- a/util/castep2force
+++ b/util/castep2force
@@ -271,7 +271,7 @@ def parse_cli_flags(argv: List[str]) -> argparse.Namespace:
         "--potential",
         type=str,
         required=True,
-        help="chemical potentials for the elements used in atomic units in the format Element1=Potential1,Element2=Potential2. For example Ar=0.01,Si=0.01,Ne=0.01",
+        help="chemical potentials for the elements used in electronvolts in the format Element1=Potential1,Element2=Potential2. For example Ar=0.01,Si=0.01,Ne=0.01",
     )
     parser.add_argument(
         "-o",


### PR DESCRIPTION
It was pointed out to me that the documentation is inconsistent for castep2force, with the written documentation stating the unit of chemical potential is electronvolts yet the built in help states that it is in atomic units. Reviewing the code, I determined that the correct unit is electronvolts and so have corrected this. The output of the `--help` flag is included in the wiki which changes with this commit, which would correct the inconsistency found there.